### PR TITLE
Use CLI version 9.5.1

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -15,7 +15,7 @@ source /dev/stdin <<< "$(curl -s --retry 3 https://lang-common.s3.amazonaws.com/
 BUILD_DIR=$1
 CACHE_DIR=$2
 BUILDPACK_DIR="$(dirname $(dirname "$0"))"
-HEROKU_CLI_URL="https://cli-assets.heroku.com/channels/stable/heroku-linux-x64.tar.xz"
+HEROKU_CLI_URL="https://cli-assets.heroku.com/versions/9.5.1/1aaf605/heroku-v9.5.1-1aaf605-linux-x64.tar.xz"
 
 puts_step "Fetching and vendoring Heroku CLI into slug"
 rm -rf "$BUILD_DIR/.heroku/cli"


### PR DESCRIPTION
Hardcode the heroku CLI version to `9.5.1`.

This is to workaround a [bug in later versions of the CLI]( https://github.com/heroku/cli/issues/3146#issuecomment-2567699938) and was suggested by Heroku Support in ticket [1488644](https://help.heroku.com/1488644)

Once the bug is fixed we can go back to the default buildpack and remove this fork.